### PR TITLE
Small correction in the check_unilateral_scenario_gain_computations method

### DIFF
--- a/tax_deficit_simulator/calculator.py
+++ b/tax_deficit_simulator/calculator.py
@@ -1012,10 +1012,14 @@ class TaxDeficitCalculator:
 
             column_name = f'Collectible tax deficit for {country}'
 
-            # We fetch the tax deficit that could be collected from the country's own multinationals
-            output['Own tax deficit'].append(
-                df[df['Parent jurisdiction (whitespaces cleaned)'] == country][column_name].iloc[0]
-            )
+            if country in df['Parent jurisdiction (whitespaces cleaned)'].unique():
+                # We fetch the tax deficit that could be collected from the country's own multinationals
+                output['Own tax deficit'].append(
+                    df[df['Parent jurisdiction (whitespaces cleaned)'] == country][column_name].iloc[0]
+                )
+
+            else:
+                output['Own tax deficit'].append(0)
 
             # We fetch the tax deficit that could be collected from US multinationals
             if 'United States' in df['Parent jurisdiction (whitespaces cleaned)'].values:


### PR DESCRIPTION
This PR introduces a small correction in the `check_unilateral_scenario_gain_computations` method. Indeed, at low minimum ETRs, since Korea does not display any tax deficit to be collected from its own multinationals, the following was breaking: 

```
output['Own tax deficit'].append(
     df[df['Parent jurisdiction (whitespaces cleaned)'] == country][column_name].iloc[0]
)
```

Where `df` is the table with the origins of the country's collectible tax deficit in the unilateral scenario. 